### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # For non-forks, we will maintain a sibling PR
   restyled:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/laniksj-zsh-theme/security/code-scanning/3](https://github.com/LanikSJ/laniksj-zsh-theme/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job. For example:
- The `restyled` job requires read access to repository contents and write access to pull requests.
- The `restyled-fork` job may only require read access to repository contents.
- The `restyled-cleanup` job requires read access to repository contents and write access to pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
