### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   Scan-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/laniksj-zsh-theme/security/code-scanning/4](https://github.com/LanikSJ/laniksj-zsh-theme/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for the `actions/checkout` step, and the `security-events: write` permission is required for the `github/codeql-action/upload-sarif` step. These permissions will be applied to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
