### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 10 1 1 *' # 10:00 AM on January 1
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   action-update-license-year:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/laniksj-zsh-theme/security/code-scanning/5](https://github.com/LanikSJ/laniksj-zsh-theme/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's tasks, it needs `contents: read` for repository access and `pull-requests: write` for merging pull requests. The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `action-update-license-year` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
