### PR TITLE
chore(markdownlint): migrate markdownlint config to toml

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-    "default": true,
-    "MD013": {
-        "line_length": 120
-    },
-    "MD041": false
-}

--- a/.markdownlint.toml
+++ b/.markdownlint.toml
@@ -1,0 +1,6 @@
+default = true
+
+[MD013]
+line_length = 120
+
+MD041 = false


### PR DESCRIPTION
Migrates the markdownlint configuration from JSON to TOML format, preserving all existing rule overrides.

- Deletes `.markdownlint.json`
- Adds `.markdownlint.toml` with identical linting rules
