### PR TITLE
chore: add .editorconfig to enforce consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+tab_width = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 140
+
+[*.{js,ts,jsx,tsx,json,md}]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
- Add a project‑wide .editorconfig file defining indentation (2 spaces), line endings (LF), charset (UTF‑8), trailing whitespace trimming, final newline insertion, and a max line length of 140 characters.
- This ensures consistent formatting across editors and IDEs for JavaScript/TypeScript, JSON, Markdown, and YAML files.
